### PR TITLE
Live buffers

### DIFF
--- a/examples/example_data_settings.json
+++ b/examples/example_data_settings.json
@@ -12,7 +12,6 @@
     "fluorescence_trigger_mode": "edge",
     "fluorescence_exposure_us": 1000.0,
     "frame_buffer_length": 1000,
-    "frame_num": 0,
     "image_denoise": 0,
     "laser_trigger_pin": 22,
     "live": 0,

--- a/examples/example_data_settings.json
+++ b/examples/example_data_settings.json
@@ -1,5 +1,5 @@
 {
-    "analyse_time_s": 1000,
+    "analyse_time_s": 100000,
     "awb_mode": "off",
     "brightfield_framerate": 80,
     "brightfield_resolution": 115,
@@ -11,7 +11,7 @@
     },
     "fluorescence_trigger_mode": "edge",
     "fluorescence_exposure_us": 1000.0,
-    "frame_buffer_length": 100,
+    "frame_buffer_length": 1000,
     "frame_num": 0,
     "image_denoise": 0,
     "laser_trigger_pin": 22,

--- a/open_optical_gating/cli/determine_reference_period.py
+++ b/open_optical_gating/cli/determine_reference_period.py
@@ -50,7 +50,7 @@ def establish_indices(sequence, period_history, settings):
         Returns:
             List of indices that form the reference sequence (or None).
     """
-
+    logger.debug("Attempting to determine reference period.")
     if len(sequence) > 1:
         frame = sequence[-1]
         pastFrames = sequence[:-1]
@@ -91,6 +91,11 @@ def establish_indices(sequence, period_history, settings):
             numRefs = int(periodToUse + 1) + (2 * settings["numExtraRefFrames"])
 
             # return start, stop, settings
+            logger.debug(
+                "Start index: {0}; Stop index: {1};",
+                len(pastFrames) - numRefs,
+                len(pastFrames),
+            )
             return len(pastFrames) - numRefs, len(pastFrames), settings
 
     logger.info("I didn't find a period I'm happy with!")

--- a/open_optical_gating/cli/determine_reference_period.py
+++ b/open_optical_gating/cli/determine_reference_period.py
@@ -56,10 +56,7 @@ def establish_indices(sequence, period_history, settings):
         pastFrames = sequence[:-1]
 
         # Calculate Diffs between this frame and previous frames in the sequence
-        # TODO we should be able to remove these np.array and dtypes
-        diffs = jps.sad_with_references(
-            np.array(frame, dtype=np.uint8), np.array(pastFrames, dtype=np.uint8)
-        )
+        diffs = jps.sad_with_references(frame, pastFrames)
 
         # Calculate Period based on these Diffs
         period = calculate_period_length(diffs)

--- a/open_optical_gating/cli/determine_reference_period.py
+++ b/open_optical_gating/cli/determine_reference_period.py
@@ -32,9 +32,9 @@ def establish(sequence, period_history, settings):
         Returns:
             List of frame pixel arrays that form the reference sequence (or None).
     """
-    referenceFrameIdx, settings = establish_indices(sequence, period_history, settings)
-    if referenceFrameIdx is not None:
-        referenceFrames = sequence[referenceFrameIdx[0] : referenceFrameIdx[-1]]
+    start, stop, settings = establish_indices(sequence, period_history, settings)
+    if start is not None and stop is not None:
+        referenceFrames = sequence[start:stop]
     else:
         referenceFrames = None
 
@@ -89,13 +89,12 @@ def establish_indices(sequence, period_history, settings):
             )  # automatically does referenceFrameCount an targetSyncPhase
             # DevNote: int(x+1) is the same as np.ceil(x).astype(np.int)
             numRefs = int(periodToUse + 1) + (2 * settings["numExtraRefFrames"])
-            return (
-                np.arange(len(pastFrames) - numRefs, len(pastFrames), dtype=int),
-                settings,
-            )
+
+            # return start, stop, settings
+            return len(pastFrames) - numRefs, len(pastFrames), settings
 
     logger.info("I didn't find a period I'm happy with!")
-    return None, settings
+    return None, None, settings
 
 
 def calculate_period_length(diffs):

--- a/open_optical_gating/cli/file_optical_gater.py
+++ b/open_optical_gating/cli/file_optical_gater.py
@@ -41,7 +41,6 @@ class FileOpticalGater(server.OpticalGater):
         """Apply data source-related settings."""
         # Data-source settings
         logger.success("Loading image data...")
-        self.frame_num = self.settings["frame_num"]
         self.data = io.imread(filename)
         self.height, self.width = self.data[0].shape
         self.framerate = self.settings["brightfield_framerate"]

--- a/open_optical_gating/cli/file_optical_gater.py
+++ b/open_optical_gating/cli/file_optical_gater.py
@@ -24,10 +24,14 @@ class FileOpticalGater(server.OpticalGater):
         settings=None,
         ref_frames=None,
         ref_frame_period=None,
+        repeats=1
     ):
         """Function inputs:
             file_source_path   str   Path to file we will read as our input
             settings           dict  Parameters affecting operation (see default_settings.json)
+            repeats            int   Number of times to repeat the frames in the source file.
+                                     It may be useful to run through the frames more than once,
+                                     for more sustained testing.
         """
 
         # initialise parent
@@ -36,9 +40,10 @@ class FileOpticalGater(server.OpticalGater):
         )
         self.load_data(file_source_path)
         self.next_frame_index = 0
-        self.automatic_target_frame = (
-            False  # ask user for their preferred initial target frame
-        )
+        self.last_frame_wallclock_time = None
+        self.repeats_remaining = repeats
+        # By default we will ask user for their preferred initial target frame
+        self.automatic_target_frame = False
 
     def load_data(self, filename):
         """Apply data source-related settings."""
@@ -53,27 +58,28 @@ class FileOpticalGater(server.OpticalGater):
         """This function gets the next frame from the data source, which can be passed to analyze()"""
         # Force framerate to match the brightfield_framerate in the settings
         # This gives accurate timings and plots
-        if force_framerate and (
-            len(self.frame_history) > 0
-        ):  # only do once we have frames
-            # how long to wait
-            # i.e. expected time per frame (1/framerate)
-            # minus how long we've spent doing stuff
-            # i.e. current time - start time - frame timestamp
-            # (which is some (some time in the past - start time))
-            # the use of start time just keeps are time stamps small
+        if force_framerate and (self.last_frame_wallclock_time is not None):
             wait_s = (1 / self.settings["brightfield_framerate"]) - (
-                time.time()
-                - self.start_time
-                - self.frame_history[-1].metadata["timestamp"]
+                time.time() - self.last_frame_wallclock_time
             )
-            if wait_s > 1e-5:
-                time.sleep(
-                    wait_s - 1e-5
-                )  # the 1e-5 is a very small time to allow for the calculation
+            if wait_s > 1e-9:
+                # the 1e-9 is a very small time to allow for the calculation
+                time.sleep(wait_s - 1e-9)
+            else:
+                logger.warning('Failing to sustain requested framerate {0}fps for frame {1} (requested negative delay {2}s)'.format(
+                    self.settings["brightfield_framerate"],
+                    self.next_frame_index,
+                    wait_s))
+    
         if self.next_frame_index == self.data.shape[0] - 1:
-            ## if this is our last frame we set the stop flag for the user/app to know
-            self.stop = True
+            self.repeats_remaining -= 1
+            if self.repeats_remaining <= 0:
+                # If this is our last frame we set the stop flag for the user/app to know
+                self.stop = True
+            else:
+                # Start again at the first frame in the file
+                self.next_frame_index = 0
+        
         next = pa.PixelArray(
             self.data[self.next_frame_index, :, :],
             metadata={
@@ -81,6 +87,7 @@ class FileOpticalGater(server.OpticalGater):
             },  # relative to start_time to sanitise
         )
         self.next_frame_index += 1
+        self.last_frame_wallclock_time = time.time()
         return next
 
 
@@ -94,7 +101,7 @@ def run(settings):
         while not analyser.stop:
             analyser.analyze_pixelarray(analyser.next_frame(force_framerate=True))
         logger.info("Requesting user input...")
-        analyser.user_select_period(10)
+        analyser.user_select_ref_frame(10)
     logger.success(
         "Period determined ({0} frames long) and user has selected frame {1} as target.",
         analyser.pog_settings["reference_period"],

--- a/open_optical_gating/cli/file_optical_gater.py
+++ b/open_optical_gating/cli/file_optical_gater.py
@@ -45,7 +45,7 @@ class FileOpticalGater(server.OpticalGater):
         self.data = io.imread(filename)
         self.height, self.width = self.data[0].shape
         self.framerate = self.settings["brightfield_framerate"]
-        self.start_time = time.time()
+        self.start_time = time.time()  # we use this to sanitise our timestamps
 
     def next_frame(self, force_framerate=False):
         """This function gets the next frame from the data source, which can be passed to analyze()"""
@@ -55,9 +55,9 @@ class FileOpticalGater(server.OpticalGater):
             len(self.frame_history) > 0
         ):  # only do once we have frames
             while (
-                time.time()
-                - self.start_time
-                - self.frame_history[-1].metadata["timestamp"]
+                time.time()  # now in seconds
+                - self.start_time  # when we started in seconds; used to sanitise
+                - self.frame_history[-1].metadata["timestamp"]  # last timestamp
             ) < (1 / self.settings["brightfield_framerate"]):
                 time.sleep(1e-5)
                 continue
@@ -66,7 +66,9 @@ class FileOpticalGater(server.OpticalGater):
             self.stop = True
         next = pa.PixelArray(
             self.data[self.next_frame_index, :, :],
-            metadata={"timestamp": time.time() - self.start_time},
+            metadata={
+                "timestamp": time.time() - self.start_time
+            },  # relative to start_time to sanitise
         )
         self.next_frame_index += 1
         return next

--- a/open_optical_gating/cli/file_optical_gater.py
+++ b/open_optical_gating/cli/file_optical_gater.py
@@ -36,6 +36,9 @@ class FileOpticalGater(server.OpticalGater):
         )
         self.load_data(file_source_path)
         self.next_frame_index = 0
+        self.automatic_target_frame = (
+            False  # ask user for their preferred initial target frame
+        )
 
     def load_data(self, filename):
         """Apply data source-related settings."""

--- a/open_optical_gating/cli/optical_gater_server.py
+++ b/open_optical_gating/cli/optical_gater_server.py
@@ -315,7 +315,7 @@ class OpticalGater:
         self.frame_num = 0  # reset the frame iterator
         self.ref_frames = None
         self.ref_buffer = []
-        self.period_history = []
+        self.period_guesses = []
 
         # TODO: JT writes: I don't like this logic - I don't feel this is the right place for it.
         # Also, update_after_n_triggers is one reason why we might want to reset the sync,
@@ -354,7 +354,7 @@ class OpticalGater:
         # Calculate period from determine_reference_period.py
         logger.info("Attempting to determine new reference period.")
         self.ref_frames, self.pog_settings = ref.establish(
-            self.ref_buffer, self.period_history, self.pog_settings
+            self.ref_buffer, self.period_guesses, self.pog_settings
         )
 
         if self.ref_frames is not None:

--- a/open_optical_gating/cli/optical_gater_server.py
+++ b/open_optical_gating/cli/optical_gater_server.py
@@ -122,7 +122,7 @@ class OpticalGater:
             and so must return before the next frame is produced.
             Essentially this method just calls through to another appropriate method, based on the current value of the state attribute."""
         logger.debug(
-            "Analysing frame.; Current time: {0}s", pixelArray.metadata["timestamp"],
+            "Analysing frame with timestamp: {0}s", pixelArray.metadata["timestamp"],
         )
 
         # For logging processing time
@@ -256,6 +256,9 @@ class OpticalGater:
             # phase (i.e. frame_history[:,1]) should be cumulative 2Pi phase
             # targetSyncPhase should be in [0,2pi]
 
+            this_predicted_trigger_time_s = self.frame_history[-1].metadata["timestamp"]
+                                            + time_to_wait_seconds
+            
             # Captures the image
             if time_to_wait_seconds > 0:
                 logger.info("Possible trigger after: {0}s", time_to_wait_seconds)
@@ -277,22 +280,14 @@ class OpticalGater:
                         time_to_wait_seconds,
                     )
                     # Trigger only
-                    self.trigger_fluorescence_image_capture(
-                        self.frame_history[-1].metadata["timestamp"]
-                        + time_to_wait_seconds
-                    )
+                    self.trigger_fluorescence_image_capture(this_predicted_trigger_time_s)
 
                     # Store trigger time and update trigger number (for adaptive algorithm)
-                    self.sent_trigger_times.append(
-                        self.frame_history[-1].metadata["timestamp"]
-                        + time_to_wait_seconds
-                    )
+                    self.sent_trigger_times.append(this_predicted_trigger_time_s)
                     self.trigger_num += 1
 
             # for prediction plotting
-            self.predicted_trigger_time_s[-1] = (
-                self.frame_history[-1].metadata["timestamp"] + time_to_wait_seconds
-            )
+            self.predicted_trigger_time_s[-1] = this_predicted_trigger_time_s
 
     def reset_state(self):
         """ Code to run when in "reset" state

--- a/open_optical_gating/cli/optical_gater_server.py
+++ b/open_optical_gating/cli/optical_gater_server.py
@@ -400,7 +400,6 @@ class OpticalGater:
         """
 
         # Start by calling through to determine_state() to establish a new reference sequence
-        # TODO: JT writes: CJN can you confirm whether we should be setting self.stop (which determine_state will do)
         # when we are in "adapt" mode like this?
         self.determine_state(pixelArray, modeString="adaptive optical gating")
 

--- a/open_optical_gating/cli/optical_gater_server.py
+++ b/open_optical_gating/cli/optical_gater_server.py
@@ -21,7 +21,7 @@ import open_optical_gating.cli.parameters as parameters
 
 logger.remove()
 logger.add(sys.stderr, level="WARNING")
-logger.add("oog_{time}.log", level="DEBUG")
+# logger.add("oog_{time}.log", level="DEBUG")
 logger.enable("open_optical_gating")
 
 # TODO create a time-stamped copy of the settings file after this

--- a/open_optical_gating/cli/parameters.py
+++ b/open_optical_gating/cli/parameters.py
@@ -25,7 +25,7 @@ def initialise(
     reference_period=0.0,
     barrierFrame=0.0,
     extrapolationFactor=1.5,
-    maxReceivedFramesToStore=260,
+    maxReceivedFramesToStore=1000,
     maxFramesForFit=32,
     minFramesForFit=3,
     prediction_latency_s=0.015,

--- a/open_optical_gating/cli/pi_optical_gater.py
+++ b/open_optical_gating/cli/pi_optical_gater.py
@@ -159,7 +159,7 @@ def run(settings):
             camera.wait_recording(0.001)  # s
         camera.stop_recording()
         # logger.info("Requesting user input...")
-        # analyser.user_select_period(10)
+        # analyser.user_select_ref_frame(10)
     logger.success(
         "Period determined ({0} frames long) and user has selected frame {1} as target.",
         analyser.pog_settings["reference_period"],

--- a/open_optical_gating/cli/pi_optical_gater.py
+++ b/open_optical_gating/cli/pi_optical_gater.py
@@ -42,6 +42,9 @@ class PiOpticalGater(server.OpticalGater):
         )
         self.setup_camera(camera)
         self.init_hardware()
+        self.automatic_target_frame = (
+            False  # ask user for their preferred initial target frame
+        )
 
     def setup_camera(self, camera):
         """Initialise and apply camera-related settings."""

--- a/open_optical_gating/cli/pi_optical_gater.py
+++ b/open_optical_gating/cli/pi_optical_gater.py
@@ -46,7 +46,6 @@ class PiOpticalGater(server.OpticalGater):
     def setup_camera(self, camera):
         """Initialise and apply camera-related settings."""
         logger.success("Configuring RPi camera...")
-        self.frame_num = self.settings["frame_num"]
         self.height, self.width = camera.resolution
         self.framerate = camera.framerate
         self.camera = camera

--- a/open_optical_gating/cli/pixelarray.py
+++ b/open_optical_gating/cli/pixelarray.py
@@ -1,4 +1,14 @@
-"""PixelArray class encapsulating a 2D camera image and its accompanying metadata"""
+"""PixelArray class encapsulating a 2D camera image and its accompanying metadata.
+
+Frame metadata:
+    Dictionary keys that are used:
+        "timestamp"         Timestamp associated with the frame.
+                            This can be in any timebase (e.g. computer, camera hardware, ...),
+                            and predicted future trigger times will be computed and returned
+                            in that same timebase.
+        "unwrapped_phase"   Unwrapped phase based on prospective optical gating phase matching.
+        "sad_min"           Position of minimum SAD with reference period.
+"""
 
 import numpy as np
 import time
@@ -13,10 +23,11 @@ class PixelArray(np.ndarray):
         obj = np.asarray(input_array).view(cls)
         obj.metadata = metadata
         return obj
-        
+
     def __array_finalize__(self, obj):
-        if obj is None: return
-        self.metadata = getattr(obj, 'metadata', dict())
+        if obj is None:
+            return
+        self.metadata = getattr(obj, "metadata", dict())
 
     def for_cbor(self):
         # Returns a representation of the array that is suitable for CBOR serialisation.
@@ -29,11 +40,13 @@ class PixelArray(np.ndarray):
         arrayData = b64encode(self.tobytes()).decode()
         return [self.shape, str(self.dtype), arrayData, self.metadata]
 
+
 def ArrayCBORDecode(jsonEncoded):
     arr = np.frombuffer(jsonEncoded[2], dtype=jsonEncoded[1]).reshape(jsonEncoded[0])
     result = PixelArray(arr)
     result.metadata = jsonEncoded[3]
     return result
+
 
 def ArrayJSONDecode(jsonEncoded):
     arrayBytes = b64decode(jsonEncoded[2])
@@ -42,15 +55,22 @@ def ArrayJSONDecode(jsonEncoded):
     result.metadata = jsonEncoded[3]
     return result
 
-def MetadataArrayFromPixelArrayList(pixelArrayList, metadataKey):
+
+def get_metadata_from_list(pixelArrayList, metadataKey):
     """ Given a list of PixelArray objects, returns a numpy array containing the
         value associated with the metadata entry for 'metadataKey' (e.g. 'timestamp')
         for each of the objects in the list. i.e. return an array containing the
         timestamp for each array object.
         
         Function inputs:
-         pixelArrayList   list     List of PixelArray objects
-         metadataKey      str      Metadata key to extract.
-                                    Must be present for all objects in pixelArrayList.
+         pixelArrayList   list          List of PixelArray objects
+         metadataKey      str or list   Metadata key to extract.
+                                        Must be present for all objects in pixelArrayList.
+                                        If a list, returns an array with n columns.
         """
-    return np.array([i.metadata[metadataKey] for i in pixelArrayList])
+    if isinstance(metadataKey, str):
+        return np.array([i.metadata[metadataKey] for i in pixelArrayList])
+    elif isinstance(metadataKey, list):
+        return np.array([[i.metadata[m] for i in pixelArrayList] for m in metadataKey])
+    else:
+        return None

--- a/open_optical_gating/cli/pixelarray.py
+++ b/open_optical_gating/cli/pixelarray.py
@@ -75,4 +75,4 @@ def get_metadata_from_list(pixelArrayList, metadataKey):
             [[i.metadata[m] for i in pixelArrayList] for m in metadataKey]
         ).T
     else:
-        return None
+        raise TypeError('Parameter metadataKey must be of type "str" or "list" (but is type "{0}")'.format(type(metadataKey)))

--- a/open_optical_gating/cli/pixelarray.py
+++ b/open_optical_gating/cli/pixelarray.py
@@ -71,6 +71,8 @@ def get_metadata_from_list(pixelArrayList, metadataKey):
     if isinstance(metadataKey, str):
         return np.array([i.metadata[metadataKey] for i in pixelArrayList])
     elif isinstance(metadataKey, list):
-        return np.array([[i.metadata[m] for i in pixelArrayList] for m in metadataKey])
+        return np.array(
+            [[i.metadata[m] for i in pixelArrayList] for m in metadataKey]
+        ).T
     else:
         return None

--- a/open_optical_gating/cli/pixelarray.py
+++ b/open_optical_gating/cli/pixelarray.py
@@ -18,10 +18,22 @@ from pybase64 import b64encode, b64decode
 class PixelArray(np.ndarray):
     # See explanations at https://numpy.org/doc/stable/user/basics.subclassing.html
     def __new__(cls, input_array, metadata=dict()):
-        # Input array is an already formed ndarray instance
+        # Input array is an already formed ndarray (or subclass) instance
         # We first cast to be our class type
         obj = np.asarray(input_array).view(cls)
-        obj.metadata = metadata
+        
+        # TODO: I would like to do the following test here:
+        #if (isinstance(input_array, PixelArray)):
+        # ... but we end up comparing <class 'open_optical_gating.cli.pixelarray.PixelArray'>
+        #     with <class 'pixelarray.PixelArray'>, which is not the same.
+        #     We need to work out how to deal with that issue, but for now I can hack it
+        #     by testing for the case where input_array is NOT of the exact type np.ndarray
+        if not type(input_array) == np.ndarray:
+            if len(metadata) != 0:
+                raise TypeError("Cannot provide out-of-line metadata when constructing from an existing PixelArray object (with its own metadata)")
+            obj.metadata = input_array.metadata.copy()
+        else:
+            obj.metadata = metadata.copy()
         return obj
 
     def __array_finalize__(self, obj):

--- a/open_optical_gating/cli/pixelarray.py
+++ b/open_optical_gating/cli/pixelarray.py
@@ -2,12 +2,14 @@
 
 Frame metadata:
     Dictionary keys that are used:
-        "timestamp"         Timestamp associated with the frame.
-                            This can be in any timebase (e.g. computer, camera hardware, ...),
-                            and predicted future trigger times will be computed and returned
-                            in that same timebase.
-        "unwrapped_phase"   Unwrapped phase based on prospective optical gating phase matching.
-        "sad_min"           Position of minimum SAD with reference period.
+        "timestamp"                 Timestamp associated with the frame.
+                                    This can be in any timebase (e.g. computer, camera hardware, ...), and predicted future trigger times will be computed and returned
+                                    in that same timebase.
+        "unwrapped_phase"           Unwrapped phase based on prospective optical gating phase matching.
+        "sad_min"                   Position of minimum SAD with reference period.
+        "predicted_trigger_time_s"  The predicted trigger as determined by prospective optical gating
+        "trigger_type_sent"         Trigger type sent; 0 is no trigger; 1 and 2 are a sent trigger
+        "processing_rate_fps"       Current frame processing rate in frames per second
 """
 
 import numpy as np
@@ -21,16 +23,18 @@ class PixelArray(np.ndarray):
         # Input array is an already formed ndarray (or subclass) instance
         # We first cast to be our class type
         obj = np.asarray(input_array).view(cls)
-        
+
         # TODO: I would like to do the following test here:
-        #if (isinstance(input_array, PixelArray)):
+        # if (isinstance(input_array, PixelArray)):
         # ... but we end up comparing <class 'open_optical_gating.cli.pixelarray.PixelArray'>
         #     with <class 'pixelarray.PixelArray'>, which is not the same.
         #     We need to work out how to deal with that issue, but for now I can hack it
         #     by testing for the case where input_array is NOT of the exact type np.ndarray
         if not type(input_array) == np.ndarray:
             if len(metadata) != 0:
-                raise TypeError("Cannot provide out-of-line metadata when constructing from an existing PixelArray object (with its own metadata)")
+                raise TypeError(
+                    "Cannot provide out-of-line metadata when constructing from an existing PixelArray object (with its own metadata)"
+                )
             obj.metadata = input_array.metadata.copy()
         else:
             obj.metadata = metadata.copy()
@@ -87,4 +91,8 @@ def get_metadata_from_list(pixelArrayList, metadataKey):
             [[i.metadata[m] for i in pixelArrayList] for m in metadataKey]
         ).T
     else:
-        raise TypeError('Parameter metadataKey must be of type "str" or "list" (but is type "{0}")'.format(type(metadataKey)))
+        raise TypeError(
+            'Parameter metadataKey must be of type "str" or "list" (but is type "{0}")'.format(
+                type(metadataKey)
+            )
+        )

--- a/open_optical_gating/cli/prospective_optical_gating.py
+++ b/open_optical_gating/cli/prospective_optical_gating.py
@@ -46,12 +46,8 @@ def update_drift(frame0, bestMatch0, settings):
 
     candidateShifts = [[0, 0], [1, 0], [-1, 0], [0, 1], [0, -1]]
 
-    # Build up a set of frames each representing a window into frame0 with slightly different drift offsets
-    frames = np.zeros(
-        [len(candidateShifts), bestMatch.shape[0], bestMatch.shape[1]],
-        dtype=frame0.dtype,
-    )
-    counter = 0
+    # Build up a list of frames, each representing a window into frame0 with slightly different drift offsets
+    frames = []
     for shft in candidateShifts:
         dxp = dx + shft[0]
         dyp = dy + shft[1]
@@ -63,8 +59,7 @@ def update_drift(frame0, bestMatch0, settings):
         rectF[2] -= dyp
         rectF[3] -= dyp
 
-        frames[counter, :, :] = frame0[rectF[0] : rectF[1], rectF[2] : rectF[3]]
-        counter = counter + 1
+        frames.append(frame0[rectF[0] : rectF[1], rectF[2] : rectF[3]])
 
     # Compare all these candidate shifted images against the matching reference frame, and find the best-matching shift
     sad = jps.sad_with_references(bestMatch, frames)

--- a/open_optical_gating/cli/prospective_optical_gating.py
+++ b/open_optical_gating/cli/prospective_optical_gating.py
@@ -508,7 +508,7 @@ def decide_trigger(timestamp, timeToWaitInSeconds, settings):
             settings                dict    Parameters controlling the sync algorithms
         Returns:
             timeToWaitInSeconds     float   Time delay before trigger would need to be sent.
-                                             Note that this returned  may be modified from its input value (see code below).
+                                             Note that this return value may be modified from its input value (see code below).
             sendIt                  int     Nonzero indicates that a trigger for the fluorescence camera should be scheduled now,
                                              for a time timeToWaitInSeconds into the future.
             settings                dict    Updated settings dictionary

--- a/open_optical_gating/cli/prospective_optical_gating.py
+++ b/open_optical_gating/cli/prospective_optical_gating.py
@@ -438,8 +438,8 @@ def pick_target_and_barrier_frames(reference_frames, settings):
     # The greatest diff (most rapid change) tends to come soon after the region of minimum change. The greatest diff tends to be a sharp peak (whereas, almost by definition, the minimum change is broader) We use the greatest diff as our "universal"(ish) reference point, but default to a phase 1/3 of a period after it, so that we get a good clear run-up to it with well-defined phases in our history.
 
     # Use v-fitting to find a sub-frame estimate of the maximum
-    if max_pos_without_padding <= 0:
-        # It looks as if the best position is right at the start of the dataset. Presumably due to a slightly glitch it's possible that the true minimum lies just outside the dataset. However, in pathological datasets there could be no minimum in easy reach at all, so we've got to give up at some point. Therefore, if we hit this condition, we just decide the best offset is 0.0. In sensible cases, that will be very close to optimum. In messy cases, this entire function is going to do unpredictable things anyway, so who cares!
+    if (max_pos_without_padding <= 0) or (max_pos_without_padding == deltas_without_padding.size - 1):
+        # It looks as if the best position is right at the start or end of the dataset. Presumably due to a slightly glitch it's possible that the true minimum lies just outside the dataset. However, in pathological datasets there could be no minimum in easy reach at all, so we've got to give up at some point. Therefore, if we hit this condition, we just decide the best offset is 0.0. In sensible cases, that will be very close to optimum. In messy cases, this entire function is going to do unpredictable things anyway, so who cares!
         target_frame_without_padding = 0
     else:
         target_frame_without_padding = (

--- a/open_optical_gating/cli/websockets_example_client.py
+++ b/open_optical_gating/cli/websockets_example_client.py
@@ -2,6 +2,7 @@ import websockets, asyncio
 import sys, time
 import numpy as np
 import json
+import matplotlib.pyplot as plt
 
 from pixelarray import PixelArray
 from file_optical_gater import FileOpticalGater
@@ -34,7 +35,7 @@ async def send_frame(websocket, frame=None):
 
         print("Array creation {0:.3f}ms, json.dumps {1:.3f}ms, websocket.send {2:.3f}ms".format((t1-t0)*1e3, (t2-t1)*1e3, (t3-t2)*1e3))
         try:
-            decT = arrBack.metadata['decodeTimes']
+            decT = arrBack.metadata["decodeTimes"]
         except:
             decT = [0, 0]
         print("Received at server {0:.3f}ms after send started, decode {1:.3f}ms and server ready to use object".format((decT[0]-t2)*1e3,
@@ -60,9 +61,14 @@ async def send_from_file(uri, settings):
         # We do instantiate a FileOpticalGater object, but actually all we use it for is to get frames from the file.
         # We don't then ask it to analyze those frames, we just send them on to the server.
         file_source = FileOpticalGater(file_source_path=settings["path"], settings=settings)
+        phases = []
         while not file_source.stop:
             response = await send_frame(websocket, file_source.next_frame())
             print("Got sync response: ", response)
+            if "phase" in response["sync"]:
+                phases.append(response["sync"]["phase"])
+        plt.plot(phases)
+        plt.show()
 
 if __name__ == "__main__":
     uri = "ws://localhost:8765"

--- a/poetry.lock
+++ b/poetry.lock
@@ -141,6 +141,7 @@ version = "1.0"
 reference = "3426263cb95b8ddb919d26bc52cd210688b1b6c8"
 type = "git"
 url = "https://github.com/abdrysdale/fastpins"
+
 [[package]]
 category = "main"
 description = "A simple framework for building complex web applications."
@@ -392,6 +393,7 @@ numba = ["numba (^0.50.1)"]
 reference = "86bcb8cc71c8db024cef910a0e1a7a94a12bfc8a"
 type = "git"
 url = "https://github.com/Glasgow-ICG/optical-gating-alignment"
+
 [[package]]
 category = "main"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
@@ -480,6 +482,17 @@ name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.9.0"
+
+[[package]]
+category = "main"
+description = "Fast Base64 encoding/decoding"
+name = "pybase64"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.1"
+
+[package.extras]
+test = ["pytest (>=5.0.0)"]
 
 [[package]]
 category = "dev"
@@ -730,7 +743,7 @@ rpi = ["picamera", "fastpins"]
 socket = ["orjson", "cbor"]
 
 [metadata]
-content-hash = "65d15542756d4b57806d07ee325b729340eb00f1d1cabcb2ce9c39cbaaff3547"
+content-hash = "8cdf70ee4920f7a1feeaee786d7018af5a7c1c88dc470adc7e225c018a31a546"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -1111,6 +1124,37 @@ pluggy = [
 py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+]
+pybase64 = [
+    {file = "pybase64-1.0.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:f5dffffef4190ae3b2a659051a364bce6339d23c63b26b97507725c8f58a9947"},
+    {file = "pybase64-1.0.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:479cc0adee267beba63e54e3ba19ac2c5f3a8f32e2184f1e0d7bb1ecf9df103b"},
+    {file = "pybase64-1.0.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:a493d50ae696cfcbff659cc2935c449396360df900f77745b0ceec1d3e14e6bc"},
+    {file = "pybase64-1.0.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:62d1854c76b84b8bd98d38fc64c6bd49a976b6a440ebb06f16e0d9fe272a5417"},
+    {file = "pybase64-1.0.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9313cf13a8c92b8831cc0a02fd176f9467d6144adb3f40bd4dec5b65d1dc2d9c"},
+    {file = "pybase64-1.0.1-cp35-cp35m-win32.whl", hash = "sha256:fb2ecba45831da747a8f5d7dd364c87ebfd709e89f2eac44be07b1319f75715b"},
+    {file = "pybase64-1.0.1-cp35-cp35m-win_amd64.whl", hash = "sha256:091154da3232cf46880a0b459955a0a240d2d6e5a090242f164da6a47c6fc4cb"},
+    {file = "pybase64-1.0.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:b941ab9bc32ce0ff17d711921af7f5537f6d4d6c382340cc38bd36793ea08ea5"},
+    {file = "pybase64-1.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9a807f9b80979628b56302d96280f6a7529e911a72fcf3bc7483e8b12585a92b"},
+    {file = "pybase64-1.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:177dba666ef67604ad4a5440995abd5f8eccbe6266a2ab23bef311ea7c767d6f"},
+    {file = "pybase64-1.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f03a4562fd90a39419243c82a9165fc2014033e4c1aaa3c959983bbf32566144"},
+    {file = "pybase64-1.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:16e8dbd75eb6fe59f40147873b99c599ced8ad3aff494f645a3ab59d64114d24"},
+    {file = "pybase64-1.0.1-cp36-cp36m-win32.whl", hash = "sha256:8e1e5b06a9dba854f4e04520514c4b13936e499c3c5b7229336d4ae3fae75786"},
+    {file = "pybase64-1.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:21f5e881b953387298c5fcc437de1faae94265368dd24ca31f6f1f08cf7dd8c2"},
+    {file = "pybase64-1.0.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:0babe9456cd1ae34a3072d80f09fbd862788222d3afb6f82a4d202cba07324a6"},
+    {file = "pybase64-1.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:35f4c517b00ebe81003e6f26bc2fdd1820161f56eddf24658b0ebf7b3ef587e9"},
+    {file = "pybase64-1.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1aeee7caef83a4a5c49129fa29f3b717dbf4b071825e352f9f6e546140efbf23"},
+    {file = "pybase64-1.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b06c873a9e4c15c5b2ae0a3d980ec764c864ec9615e9421d9be25a5b477566d2"},
+    {file = "pybase64-1.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d19edbb02d1cc074d26b2546f08ba82f0f1ac502d771429de3ae5b88047bdf18"},
+    {file = "pybase64-1.0.1-cp37-cp37m-win32.whl", hash = "sha256:b7ac8e1310be11ebfb99bae5d03cecb5d110340814edd58fd84f4e666b3db185"},
+    {file = "pybase64-1.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:61d6307760b62ddb2b930178e2447046988854fbf99877d665d4800b21c2849c"},
+    {file = "pybase64-1.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4fe0e8ce35fc8a7839dc598ae3a9332d1de7b3a5e47dff3fe823fa22c23e0168"},
+    {file = "pybase64-1.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5302987ce48b298aea9a49891d73e3d2cd8a4303a55a41cf9b4e39449eee2d30"},
+    {file = "pybase64-1.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:34d0149cccb0eb0fe7b769b48ff8034db4ce87f48c83eb8d5e5b83f4d14f2e9c"},
+    {file = "pybase64-1.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:1e47563426cb52599e6d79d3c5ef8383605650b1a13862a5caaa7a7e8ef5cf4f"},
+    {file = "pybase64-1.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:2e691aedcf7b79a948c65775d2e60075a9cc52b89ec6d147f72528ed5194aca8"},
+    {file = "pybase64-1.0.1-cp38-cp38-win32.whl", hash = "sha256:5e4ede60d4dd357c7c25281cb05d06fe7bc5cc03cf5c7c866459208c48694f18"},
+    {file = "pybase64-1.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:ac5febbef9f942333206bf1be2c2f06783df7b074d63fd5bf989206473610ca6"},
+    {file = "pybase64-1.0.1.tar.gz", hash = "sha256:6ced40531bffc81bafc790d5c0d2f752e281b3b00fd6ff4e79385c625e5dbab1"},
 ]
 pylint = [
     {file = "pylint-2.5.3-py3-none-any.whl", hash = "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -694,6 +694,14 @@ version = "0.2.5"
 
 [[package]]
 category = "main"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+name = "websockets"
+optional = false
+python-versions = ">=3.6.1"
+version = "8.1"
+
+[[package]]
+category = "main"
 description = "The comprehensive WSGI web application library."
 name = "werkzeug"
 optional = false
@@ -743,7 +751,7 @@ rpi = ["picamera", "fastpins"]
 socket = ["orjson", "cbor"]
 
 [metadata]
-content-hash = "8cdf70ee4920f7a1feeaee786d7018af5a7c1c88dc470adc7e225c018a31a546"
+content-hash = "4ab5a64608c98d6e26ad823827260cf8002c09d32fa9596e3576167d5718a255"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -1316,6 +1324,30 @@ typed-ast = [
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+websockets = [
+    {file = "websockets-8.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:3762791ab8b38948f0c4d281c8b2ddfa99b7e510e46bd8dfa942a5fff621068c"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3db87421956f1b0779a7564915875ba774295cc86e81bc671631379371af1170"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4f9f7d28ce1d8f1295717c2c25b732c2bc0645db3215cf757551c392177d7cb8"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:295359a2cc78736737dd88c343cd0747546b2174b5e1adc223824bcaf3e164cb"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1d3f1bf059d04a4e0eb4985a887d49195e15ebabc42364f4eb564b1d065793f5"},
+    {file = "websockets-8.1-cp36-cp36m-win32.whl", hash = "sha256:2db62a9142e88535038a6bcfea70ef9447696ea77891aebb730a333a51ed559a"},
+    {file = "websockets-8.1-cp36-cp36m-win_amd64.whl", hash = "sha256:0e4fb4de42701340bd2353bb2eee45314651caa6ccee80dbd5f5d5978888fed5"},
+    {file = "websockets-8.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:9b248ba3dd8a03b1a10b19efe7d4f7fa41d158fdaa95e2cf65af5a7b95a4f989"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ce85b06a10fc65e6143518b96d3dca27b081a740bae261c2fb20375801a9d56d"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:965889d9f0e2a75edd81a07592d0ced54daa5b0785f57dc429c378edbcffe779"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:751a556205d8245ff94aeef23546a1113b1dd4f6e4d102ded66c39b99c2ce6c8"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3ef56fcc7b1ff90de46ccd5a687bbd13a3180132268c4254fc0fa44ecf4fc422"},
+    {file = "websockets-8.1-cp37-cp37m-win32.whl", hash = "sha256:7ff46d441db78241f4c6c27b3868c9ae71473fe03341340d2dfdbe8d79310acc"},
+    {file = "websockets-8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:20891f0dddade307ffddf593c733a3fdb6b83e6f9eef85908113e628fa5a8308"},
+    {file = "websockets-8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c1ec8db4fac31850286b7cd3b9c0e1b944204668b8eb721674916d4e28744092"},
+    {file = "websockets-8.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5c01fd846263a75bc8a2b9542606927cfad57e7282965d96b93c387622487485"},
+    {file = "websockets-8.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9bef37ee224e104a413f0780e29adb3e514a5b698aabe0d969a6ba426b8435d1"},
+    {file = "websockets-8.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d705f8aeecdf3262379644e4b55107a3b55860eb812b673b28d0fbc347a60c55"},
+    {file = "websockets-8.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:c8a116feafdb1f84607cb3b14aa1418424ae71fee131642fc568d21423b51824"},
+    {file = "websockets-8.1-cp38-cp38-win32.whl", hash = "sha256:e898a0863421650f0bebac8ba40840fc02258ef4714cb7e1fd76b6a6354bda36"},
+    {file = "websockets-8.1-cp38-cp38-win_amd64.whl", hash = "sha256:f8a7bff6e8664afc4e6c28b983845c5bc14965030e3fb98789734d416af77c4b"},
+    {file = "websockets-8.1.tar.gz", hash = "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ numba = { version = "^0.50.1", optional = true}
 # RPi Specific
 picamera = { version = "^1.13", optional = true}
 fastpins = { git = "https://github.com/abdrysdale/fastpins",  optional = true}
+pybase64 = "^1.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ flask = "^1.1.2"
 # Socket Specific
 orjson = { version = "^3.3.1", optional = true }
 cbor = { version = "^1.0.0", optional = true }
+websockets = "^8.1"
 # Numba for optical gating (not on Pi)
 numba = { version = "^0.50.1", optional = true}
 # RPi Specific
@@ -32,7 +33,7 @@ pylint = "^2.4.4"
 [tool.poetry.extras]
 numba = ["numba"]
 rpi = ["picamera", "fastpins"]
-socket = ["orjson", "cbor"]
+socket = ["orjson", "cbor", "websockets"]
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
So this is now using 'live buffers' rather than 'build up buffers' - I've done a fair part of the shifting of timestamp, unwrapped_phase and argmin(sad) into the metadata dictionary of pixelarray objects.
There's a few in-line TODOs relating to having to cast the list of PixelArrays to ndarrays before calling any jps functions. Would be good to get jps happy with lists.
This is also matched be a similar series of commits (on the main branch) in optical-gating-alignment

Closes #10 